### PR TITLE
add type convertor for alpha if given arch

### DIFF
--- a/easytransfer/model_zoo/modeling_adabert.py
+++ b/easytransfer/model_zoo/modeling_adabert.py
@@ -555,7 +555,7 @@ class AdaBERTStudent(object):
                           h1_res, h1_skip])
             op_weights = tf.reshape(alpha, [-1, 1, 1, 1])
             # (bs, seq_len, emb_dim)
-            h = tf.reduce_sum(h * op_weights, 0)
+            h = tf.reduce_sum(h * tf.to_float(op_weights), 0)
         return h
 
     def build_cnn3(self, x, is_training):

--- a/easytransfer/model_zoo/modeling_adabert.py
+++ b/easytransfer/model_zoo/modeling_adabert.py
@@ -497,7 +497,7 @@ class AdaBERTStudent(object):
                     tf.logging.info("excluded edge {}-{}".format(src, index))
                     continue
                 states.append(
-                    self.build_edge(h, arch_params[(src, index)] if arch_params else given_arch[(src, index)],
+                    self.build_edge(h, arch_params[(src, index)] if arch_params else int(given_arch[(src, index)]),
                                     is_training, src, index))
         return tf.add_n(states)
 


### PR DESCRIPTION
Arch is given in finetune stage. 
`op_weights` then would be an instance of int. 
This may cause type issues in tf-1.15 when further applying it to a `mul` op.